### PR TITLE
Add AASA for iOS.

### DIFF
--- a/.well-known/apple-app-site-association
+++ b/.well-known/apple-app-site-association
@@ -1,0 +1,12 @@
+
+{
+  "applinks": {
+      "apps": [],
+      "details": [
+           {
+             "appID": "A35W4MM59Y.edu.mit.eduwallet",
+             "paths": [ "*" ]
+           }
+       ]
+   }
+}


### PR DESCRIPTION
Associating lcw.app domain with LCW. Addresses issue https://github.com/digitalcredentials/learner-credential-wallet/issues/505