### PR TITLE
Associate app.lcw with Android app.

### DIFF
--- a/.well-known/assetlinks.json
+++ b/.well-known/assetlinks.json
@@ -1,0 +1,9 @@
+[{
+  "relation": ["delegate_permission/common.handle_all_urls"],
+  "target": {
+    "namespace": "android_app",
+    "package_name": "app.lcw",
+    "sha256_cert_fingerprints":
+    ["8F:1E:73:DA:FE:CD:F9:08:2E:0E:42:BD:EC:D4:55:A4:99:AE:30:96:28:E9:16:CC:58:B4:0A:FB:9A:E0:77:0C"]
+  }
+}]


### PR DESCRIPTION
Adds association for the domain for Android side of LCW. Partly addresses issue https://github.com/digitalcredentials/learner-credential-wallet/issues/505