### PR TITLE
New blurb for public link section of FAQ site

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -50,7 +50,7 @@
 					<p class="p-small">Creating a Public Link is a voluntary process. We provide this functionality so you may choose to share a credential from your wallet to anyone with the link.</p>
 					<p class="p-small">Creating a public link will generate a webpage to display the contents of a credential on the <a href="https://verifierplus.org/">VerifierPlus</a> website managed by the <a href="https://digitalcredentials.mit.edu/">Digital Credentials Consortium</a>. You are fully in control of how and with whom you share this link.</p>
 					<p class="p-small">The Public Link is governed by the <a href="https://verifierplus.org/">VerifierPlus</a> <a href="https://verifierplus.org/terms">Terms and Conditions of Use</a> and <a href="https://verifierplus.org/privacy">Privacy Policy</a>.</p>
-					<p class="p-small">During the VerifierPlus beta, all Public Links are set to automatically expire 1 year after creation.</p>
+					<p class="p-small">All Public Links are set to automatically expire 1 year after creation. Please note that a public link expiration date is not the same as the expiration date for your credential.</p>
 
 					<h2 class="mt-4 mb-3"><a name="public-link-more" />What can others do with a “Public Link”?</h2>
 					<p class="p-small">Anyone with the link will be able to view the credential that is shared via a "Public Link". We recommend you consider where, to whom and how frequently you share a “Public Link”.</p>


### PR DESCRIPTION
Addresses part of https://github.com/openwallet-foundation-labs/learner-credential-wallet/issues/446. 