### PR TITLE
18: Automate versioning on lcw.app site

### DIFF
--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -1,0 +1,35 @@
+name: Update App Version
+on:
+  schedule:
+    - cron: '0 12 * * 1'  # Every monday
+  workflow_dispatch:
+  repository_dispatch:
+    types: [new-release]
+
+jobs:
+  update-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      
+      - name: Get and check version
+        id: version
+        run: |
+          NEW_VERSION=$(curl -s https://api.github.com/repos/openwallet-foundation-labs/learner-credential-wallet/tags | jq -r '.[0].name')
+          CURRENT_VERSION=$(cat version.json 2>/dev/null | jq -r '.version' || echo "")
+          if [ "$NEW_VERSION" != "$CURRENT_VERSION" ]; then
+            echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
+            echo "changed=true" >> $GITHUB_OUTPUT
+            echo '{"version": "'$NEW_VERSION'"}' > version.json
+          else
+            echo "changed=false" >> $GITHUB_OUTPUT
+          fi
+          
+      - name: Commit if changed
+        if: steps.version.outputs.changed == 'true'
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add version.json
+          git commit -m "Update app version to ${{ steps.version.outputs.version }}"
+          git push

--- a/css/styles.css
+++ b/css/styles.css
@@ -84,6 +84,12 @@ footer {
 	margin-bottom: 0.5rem;
 }
 
+.version-text {
+	color: #c7c7c7;
+	font-size: 1rem;
+	margin-top: -0.5rem;
+}
+
 .p-small {
 	font-size: 1rem;
 }

--- a/index.html
+++ b/index.html
@@ -40,6 +40,7 @@
                     <div class="text-container text-center">
                         <img class="lcw-icon mt-4" src="images/lcw-icon.png" alt="Learner Credential Wallet icon consisting of folders">
                         <p class="title text-center">Learner Credential Wallet</p>
+                        <p class="version-text text-center" id="app-version"></p>
                         <h2 class="pt-2 subtitle">A place to store your learner credentials</h2>
                         <a href="https://apps.apple.com/app/learner-credential-wallet/id1590615710?"><img class="ios-icon pt-2" src="images/ios-icon.svg" alt="Download on the App Store"></a>
                         <!--<button type="button" class="btn btn-secondary btn-lg mt-3" disabled><h3 class="mb-0">Coming Soon</h3></button>-->
@@ -65,5 +66,11 @@
     <!-- Scripts -->
     <script src="js/jquery.min.js"></script> <!-- jQuery for Bootstrap's JavaScript plugins -->
     <script src="js/bootstrap.min.js"></script> <!-- Bootstrap framework -->
+    <script>
+        fetch('version.json').then(r=>r.json()).then(d=>{
+            const version = d.version.replace(/v(\d+\.\d+\.\d+)-build(\d+)/, 'v$1 - Build $2');
+            document.getElementById('app-version').textContent = version;
+        }).catch(()=>{});
+    </script>
 </body>
 </html>

--- a/version.json
+++ b/version.json
@@ -1,0 +1,1 @@
+{"version": "v2.2.7-build101"}


### PR DESCRIPTION
Created PR for #18 

Implements automatic fetching and display of the latest mobile app version on the website homepage.

- Fetches latest version from openwallet-foundation-labs/learner-credential-wallet tags
- Runs weekly on Mondays at 12:00 PM UTC
- Only commits when version actually changes (prevents unnecessary commits)
-  version.json - stores current app version
- Updated automatically by GitHub Actions

## Screenshot
<img width="1122" height="905" alt="Screenshot 2025-11-07 at 4 04 26 PM" src="https://github.com/user-attachments/assets/3e4e6a8c-a4ff-4ce6-92df-3eb845caa934" />
